### PR TITLE
Add help screen for bridge components

### DIFF
--- a/src/DevToolsStyling.css.js
+++ b/src/DevToolsStyling.css.js
@@ -13,6 +13,31 @@ export const cssContent = () => {
       box-sizing: border-box;
     }
 
+    a {
+      color: white;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      margin: 0;
+    }
+
+    .btn-icon {
+      background-color: transparent;
+      border: none;
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.5em;
+      height: 100%;
+    }
+
+    .btn-icon svg {
+      width: 1rem;
+      height: 1rem;
+      fill: white;
+    }
+
     /* Debug bubble */
     #debug-bubble {
       display: flex;
@@ -180,17 +205,6 @@ export const cssContent = () => {
       display: flex;
     }
 
-    .bottom-sheet .tab-action-bar button {
-      background-color: transparent;
-      border: none;
-      color: white;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.5em;
-      height: 100%;
-    }
-
     .bottom-sheet .tab-action-bar button:active svg {
       fill: #6c6c6c;
     }
@@ -198,12 +212,6 @@ export const cssContent = () => {
     .bottom-sheet .btn-clear-tab,
     .bottom-sheet .btn-reload-tab {
       margin-left: auto;
-    }
-    .bottom-sheet .btn-clear-tab svg,
-    .bottom-sheet .btn-reload-tab svg {
-      width: 1rem;
-      height: 1rem;
-      fill: white;
     }
 
     /* Bottom Sheet Tabs */
@@ -250,6 +258,9 @@ export const cssContent = () => {
       padding: 1rem;
       overflow-x: auto;
       white-space: nowrap;
+    }
+    .single-tab-content .inner-tab-content {
+      white-space: normal;
     }
 
     .tab-empty-content {
@@ -409,6 +420,14 @@ export const cssContent = () => {
       justify-content: flex-end;
     }
 
+    .align-items-center {
+      align-items: center;
+    }
+
+    .flex-grow-1 {
+      flex-grow: 1;
+    }
+
     .no-wrap {
       overflow: hidden;
       white-space: nowrap;
@@ -420,6 +439,18 @@ export const cssContent = () => {
 
     .mt-1 {
       margin-top: 0.25rem;
+    }
+
+    .ms-1 {
+      margin-left: 0.25rem;
+    }
+
+    .mb-2 {
+      margin-bottom: 0.5rem;
+    }
+
+    .mb-3 {
+      margin-bottom: 1rem;
     }
 
     .gap-1 {

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -22,6 +22,13 @@ export const arrowDown = `
   </svg>
 `
 
+export const arrowLeft = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+    <path d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.2 288 416 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-306.7 0L214.6 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"/>
+  </svg>
+`
+
 export const trash = `
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
     <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
@@ -33,5 +40,12 @@ export const rotate = `
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
     <path d="M142.9 142.9c-17.5 17.5-30.1 38-37.8 59.8c-5.9 16.7-24.2 25.4-40.8 19.5s-25.4-24.2-19.5-40.8C55.6 150.7 73.2 122 97.6 97.6c87.2-87.2 228.3-87.5 315.8-1L455 55c6.9-6.9 17.2-8.9 26.2-5.2s14.8 12.5 14.8 22.2l0 128c0 13.3-10.7 24-24 24l-8.4 0c0 0 0 0 0 0L344 224c-9.7 0-18.5-5.8-22.2-14.8s-1.7-19.3 5.2-26.2l41.1-41.1c-62.6-61.5-163.1-61.2-225.3 1zM16 312c0-13.3 10.7-24 24-24l7.6 0 .7 0L168 288c9.7 0 18.5 5.8 22.2 14.8s1.7 19.3-5.2 26.2l-41.1 41.1c62.6 61.5 163.1 61.2 225.3-1c17.5-17.5 30.1-38 37.8-59.8c5.9-16.7 24.2-25.4 40.8-19.5s25.4 24.2 19.5 40.8c-10.8 30.6-28.4 59.3-52.9 83.8c-87.2 87.2-228.3 87.5-315.8 1L57 457c-6.9 6.9-17.2 8.9-26.2 5.2S16 449.7 16 440l0-119.6 0-.7 0-7.6z"/>
+  </svg>
+`
+
+export const questionMark = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+    <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3l58.3 0c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24l0-13.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1l-58.3 0c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/>
   </svg>
 `

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -7,3 +7,9 @@ export const debounce = (fn, delay) => {
     timeoutId = setTimeout(callback, delay)
   }
 }
+
+export const platform = () => {
+  const { bridgePlatform } = document.documentElement.dataset
+  const platform = bridgePlatform || "unknown"
+  return platform
+}


### PR DESCRIPTION
This PR introduces the concept of a "single-tab bottom sheet."
The idea is to have a way to present content that isn't related to any of the tabs.
Currently, it will be used for help pages, but future plans include using the same concept for a generic settings page.