### PR TITLE
Add `DiagnosticsChecker`

### DIFF
--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -1,6 +1,7 @@
 import DevToolsState from "./DevToolsState"
 import DebugBubble from "./DebugBubble"
 import BottomSheet from "./BottomSheet"
+import DiagnosticsChecker from "./DiagnosticsChecker"
 import CustomBridge from "./bridge/CustomBridge"
 import { debounce } from "./utils/utils"
 import { cssContent } from "./DevToolsStyling.css"
@@ -11,6 +12,7 @@ export default class DevTools {
     this.bubble = new DebugBubble(this)
     this.bottomSheet = new BottomSheet(this)
     this.customBridge = new CustomBridge(this)
+    this.diagnosticsChecker = new DiagnosticsChecker()
     this.state.subscribe(this.update.bind(this))
     this.listenForTurboEvents()
   }
@@ -50,6 +52,9 @@ export default class DevTools {
       },
       { passive: true }
     )
+
+    // Check for warnings
+    this.diagnosticsChecker.checkForWarnings()
 
     this.bubble.onClick(() => {
       this.bottomSheet.showBottomSheet()

--- a/src/DiagnosticsChecker.js
+++ b/src/DiagnosticsChecker.js
@@ -1,0 +1,58 @@
+export default class DiagnosticsChecker {
+  constructor() {
+    this.printedWarnings = []
+  }
+
+  printWarning = (message, once = true, ...extraArgs) => {
+    if (once && this.printedWarnings.includes(message)) return
+
+    console.warn(`DevTools: ${message}`, ...extraArgs)
+    this.printedWarnings.push(message)
+  }
+
+  checkForWarnings = () => {
+    this.#checkForTurboDrive()
+    this.#checkForDuplicatedTurboFrames()
+    this.#checkTurboPermanentElements()
+  }
+
+  #checkForTurboDrive = () => {
+    if (!window.Turbo) {
+      this.printWarning("Turbo is not detected. Hotwire Native will not work correctly without Turbo")
+    } else if (window.Turbo?.session.drive === false) {
+      this.printWarning("Turbo Drive is disabled. Hotwire Native will not work correctly without Turbo Drive")
+    }
+  }
+
+  #checkForDuplicatedTurboFrames = () => {
+    const turboFramesIds = this.turboFrameIds
+    const duplicatedIds = turboFramesIds.filter((id, index) => turboFramesIds.indexOf(id) !== index)
+
+    duplicatedIds.forEach((id) => {
+      this.printWarning(`Multiple Turbo Frames with the same ID '${id}' detected. This can cause unexpected behavior. Ensure that each Turbo Frame has a unique ID.`)
+    })
+  }
+
+  #checkTurboPermanentElements = () => {
+    const turboPermanentElements = document.querySelectorAll("[data-turbo-permanent]")
+    if (turboPermanentElements.length === 0) return
+
+    turboPermanentElements.forEach((element) => {
+      const id = element.id
+      if (id === "") {
+        const message = `Turbo Permanent Element detected without an ID. Turbo Permanent Elements must have a unique ID to work correctly.`
+        this.printWarning(message, true, element)
+      }
+
+      const idIsDuplicated = id && document.querySelectorAll(`#${id}`).length > 1
+      if (idIsDuplicated) {
+        const message = `Turbo Permanent Element with ID '${id}' doesn't have a unique ID. Turbo Permanent Elements must have a unique ID to work correctly.`
+        this.printWarning(message, true, element)
+      }
+    })
+  }
+
+  get turboFrameIds() {
+    return Array.from(document.querySelectorAll("turbo-frame")).map((turboFrame) => turboFrame.id)
+  }
+}


### PR DESCRIPTION
This PR introduces a diagnostic checker to detect common Turbo-related issues.

For example, if Turbo Drive is not enabled, the Hotwire Native app will launch, but all links will be treated as external. The checker provides warnings to help identify and troubleshoot such issues.