### PR TITLE
Add native bridge components

### DIFF
--- a/android/DevToolsComponent.kt
+++ b/android/DevToolsComponent.kt
@@ -1,0 +1,126 @@
+package replace.with.your.name // Replace with your package name
+
+import android.util.Log
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import replace.with.your.name.MainActivity // Replace with your package name
+import dev.hotwire.core.bridge.BridgeComponent
+import dev.hotwire.core.bridge.BridgeDelegate
+import dev.hotwire.core.bridge.Message
+import dev.hotwire.core.config.Hotwire
+import dev.hotwire.navigation.destinations.HotwireDestination
+import dev.hotwire.navigation.fragments.HotwireWebFragment
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+class DevToolsComponent(
+    name: String,
+    private val hotwireDelegate: BridgeDelegate<HotwireDestination>
+) : BridgeComponent<HotwireDestination>(name, hotwireDelegate) {
+
+    private val fragment: Fragment
+        get() = hotwireDelegate.destination.fragment
+
+    private val mainActivity: MainActivity?
+        get() = fragment.activity as? MainActivity
+
+    override fun onReceive(message: Message) {
+        when (message.event) {
+            "connect" -> handleConnect(message)
+            "currentStackInfo" -> handleCurrentStackInfo(message)
+            else -> Log.w("DevToolsComponent", "Unknown event for message: $message")
+        }
+    }
+
+    private fun handleConnect(message: Message) {
+        replyTo("connect", ConnectResultData("connected"))
+    }
+
+    private fun handleCurrentStackInfo(message: Message) {
+        val stack = getNavigationStack()
+        replyTo("currentStackInfo", Stack(stack))
+    }
+
+    private fun getNavigationStack(): List<FragmentInfo> {
+        val stack = mutableListOf<FragmentInfo>()
+
+        mainActivity?.supportFragmentManager?.let { fragmentManager ->
+            // Get the root fragments
+            stack.addAll(collectFragmentInfo(fragmentManager))
+        }
+
+        return stack
+    }
+
+    private fun collectFragmentInfo(
+        fragmentManager: FragmentManager,
+        depth: Int = 0
+    ): List<FragmentInfo> {
+        val fragments = mutableListOf<FragmentInfo>()
+
+        // Currently we don't have a good way to get the title or URL of the back stack entries
+        // Therefore we just add an empty entry for each back stack entry
+        // Hopefully we can improve this in the future
+        for (entry in 0 until fragmentManager.backStackEntryCount) {
+            fragments.add(
+                FragmentInfo(
+                    type = "BackStackEntry",
+                    title = ""
+                )
+            )
+        }
+
+        // Collect information about current fragments
+        fragmentManager.fragments.forEach { fragment ->
+            val children = if (fragment.childFragmentManager.fragments.isNotEmpty()) {
+                collectFragmentInfo(fragment.childFragmentManager, depth + 1)
+            } else {
+                emptyList()
+            }
+
+            val info = when (fragment) {
+                is HotwireWebFragment -> {
+                    val properties = Hotwire.config.pathConfiguration.properties(fragment.location)
+
+                    FragmentInfo(
+                        type = "HotwireWebFragment",
+                        title = fragment.toolbarForNavigation()?.title.toString(),
+                        url = fragment.location,
+                        pathConfigurationProperties = properties,
+                        children = children
+                    )
+                }
+                else -> {
+                    FragmentInfo(
+                        type = fragment.javaClass.simpleName,
+                        title = fragment.tag ?: "",
+                        children = children
+                    )
+                }
+            }
+
+            fragments.add(info)
+        }
+
+        return fragments
+    }
+
+    @Serializable
+    data class ConnectResultData(
+        @SerialName("callbackReason") val callbackReason: String
+    )
+
+    @Serializable
+    data class Stack(
+        val stack: List<FragmentInfo>
+    )
+
+    @Serializable
+    data class FragmentInfo(
+        val type: String,
+        val title: String,
+        val url: String? = null,
+        val pathConfigurationProperties: Map<String, String> = emptyMap(),
+        val children: List<FragmentInfo> = emptyList()
+    )
+}

--- a/ios/DevToolsComponent.swift
+++ b/ios/DevToolsComponent.swift
@@ -1,0 +1,199 @@
+import HotwireNative
+import UIKit
+
+public class DevToolsComponent: BridgeComponent {
+    public override class var name: String { "dev-tools" }
+
+    private let feedbackGenerators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [
+        .soft: UIImpactFeedbackGenerator(style: .soft),
+        .heavy: UIImpactFeedbackGenerator(style: .heavy),
+        .light: UIImpactFeedbackGenerator(style: .light)
+    ]
+
+    public override func onReceive(message: Message) {
+        guard let event = Event(rawValue: message.event) else {
+            return
+        }
+
+        switch event {
+        case .connect:
+            handleConnect()
+        case .currentStackInfo:
+            handleCurrentStackInfo()
+        case .vibrate:
+            handleVibrate(message: message)
+        }
+    }
+
+    private func handleConnect() {
+        reply(to: Event.connect.rawValue, with: connectResponseData(callbackReason: "connected"))
+        prepareHapticFeedback()
+    }
+
+    private func handleCurrentStackInfo() {
+        let stack = getViewControllerStack()
+        let container = StackContainer(stack: stack)
+
+        reply(to: Event.currentStackInfo.rawValue, with: container)
+    }
+
+    private func handleVibrate(message: Message) {
+        guard let data: VibrateMessageData = message.data() else { return }
+
+        let impactStyles: [String: UIImpactFeedbackGenerator.FeedbackStyle] = [
+            "soft": .soft,
+            "heavy": .heavy,
+            "light": .light
+        ]
+
+        let notificationStyles: [String: UINotificationFeedbackGenerator.FeedbackType] = [
+            "success": .success,
+            "warning": .warning,
+            "error": .error
+        ]
+
+        if let notificationStyle = notificationStyles[data.style ?? ""] {
+            UINotificationFeedbackGenerator().notificationOccurred(notificationStyle)
+        } else {
+            let feedbackStyle = impactStyles[data.style ?? "light"] ?? .light
+            feedbackGenerators[feedbackStyle]?.impactOccurred()
+        }
+    }
+
+    private func getViewControllerStack() -> [ScreenInfo] {
+        guard let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }),
+              let rootViewController = keyWindow.rootViewController else {
+            return []
+        }
+
+        return collectViewControllerInfo(from: rootViewController)
+    }
+
+    private func collectViewControllerInfo(from viewController: UIViewController) -> [ScreenInfo] {
+        var stack: [ScreenInfo] = []
+        var info: ScreenInfo
+
+        // Try to cast the different ViewControllers
+        if let visitableVC = viewController as? VisitableViewController {
+            // If this line raises an error, you might use an older version of Hotwire Native.
+            // In that case, use the following line instead:
+            // let url: URL? = visitableVC.visitableURL
+            let url: URL? = visitableVC.currentVisitableURL
+
+            let properties = url.map { Hotwire.config.pathConfiguration.properties(for: $0) } ?? [:]
+
+            info = ScreenInfo(
+                type: "VisitableViewController",
+                title: visitableVC.title ?? "",
+                url: url?.absoluteString,
+                pathConfigurationProperties: convertPropertiesToJSON(properties),
+                children: []
+            )
+        } else if let navigationController = viewController as? UINavigationController {
+            let childrenInfo = navigationController.viewControllers.flatMap {
+                collectViewControllerInfo(from: $0)
+            }
+            info = ScreenInfo(
+                type: "UINavigationController",
+                title: navigationController.title ?? "",
+                children: childrenInfo
+            )
+        } else if let tabBarController = viewController as? UITabBarController {
+            let childrenInfo = (tabBarController.viewControllers ?? []).flatMap {
+                collectViewControllerInfo(from: $0)
+            }
+            info = ScreenInfo(
+                type: "UITabBarController",
+                title: tabBarController.title ?? "",
+                children: childrenInfo
+            )
+        } else {
+            // Handle regular view controllers and their children
+            var children: [ScreenInfo] = []
+
+            // Add presented view controller if exists
+            if let presentedVC = viewController.presentedViewController {
+                children.append(contentsOf: collectViewControllerInfo(from: presentedVC))
+            }
+
+            // Add child view controllers
+            children.append(contentsOf: viewController.children.flatMap {
+                collectViewControllerInfo(from: $0)
+            })
+
+            info = ScreenInfo(
+                type: "Screen",
+                title: viewController.title ?? "",
+                children: children
+            )
+        }
+
+        stack.append(info)
+        return stack
+    }
+
+    // Prepares UIImpactFeedbackGenerator instances in advance to prevent lag on first use
+    private func prepareHapticFeedback() {
+        feedbackGenerators.values.forEach { $0.prepare() }
+    }
+
+    private func convertPropertiesToJSON(_ properties: [String: AnyHashable]) -> String {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: properties)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                return jsonString
+            }
+        } catch {
+            // no-op
+        }
+
+        return "{}"
+    }
+}
+
+// MARK: - Events
+
+private extension DevToolsComponent {
+    enum Event: String {
+        case connect
+        case currentStackInfo
+        case vibrate
+    }
+}
+
+// MARK: Message data
+
+private extension DevToolsComponent {
+
+    struct VibrateMessageData: Decodable {
+        let style: String?
+    }
+
+    // MARK: Response Structs
+    struct connectResponseData: Encodable {
+        let callbackReason: String
+    }
+
+    struct StackContainer: Encodable {
+        let stack: [ScreenInfo]
+    }
+
+    struct ScreenInfo: Codable {
+        let type: String
+        let title: String
+        let url: String?
+        let pathConfigurationProperties: String?
+        let children: [ScreenInfo]
+
+        init(type: String, title: String, url: String? = nil, pathConfigurationProperties: String? = nil, children: [ScreenInfo] = []) {
+            self.type = type
+            self.title = title
+            self.url = url
+            self.pathConfigurationProperties = pathConfigurationProperties
+            self.children = children
+        }
+    }
+}


### PR DESCRIPTION
Previously, the bridge components were in separate repositories and the plan was to load them as libraries.   
However, there were some technical issues with that approach, so for now, the bridge components will need to be copied into your project.

Main problem with the library approach was that specific calls to Hotwire Native are not intended to be used outside of the app.   
Like calling `Hotwire.config.pathConfiguration.properties(for: url)` in the iOS component, works fine in the app, but not in a library. 
Reason being that the config is not concurrency-safe.   
Hopefully we can find a way in the future to load the components as libraries, since that would be the easier way to use them.