### PR TITLE
Support HotwireNative window object

### DIFF
--- a/src/components/BottomSheet.js
+++ b/src/components/BottomSheet.js
@@ -210,7 +210,7 @@ export default class BottomSheet {
     container.innerHTML = this.state.bridgeLogs.length
       ? this.state.bridgeLogs.map((log) => this.bridgeLogHTML(log.direction, log.componentName, log.eventName, log.eventArgs, log.time)).join("")
       : `<div class="tab-empty-content d-flex flex-column text-center"><span>${
-          this.state.bridgeIsConnected ? "No bridge communication yet" : "Bridge is not connected <br><small>(window.Strada.web is undefined)</small>"
+          this.state.bridgeIsConnected ? "No bridge communication yet" : "Bridge is not connected <br><small>(Neither window.HotwireNative nor window.Strada is defined)</small>"
         }</span></div>`
   }
 

--- a/src/lib/NativeBridge.js
+++ b/src/lib/NativeBridge.js
@@ -7,7 +7,7 @@ https://github.com/hotwired/hotwire-native-bridge
 */
 export default class NativeBridge {
   bridgeIsConnected() {
-    return !!window.Strada?.web
+    return !!(window.HotwireNative?.web || window.Strada?.web)
   }
 
   // Send a message to the native side
@@ -43,6 +43,6 @@ export default class NativeBridge {
   }
 
   get bridge() {
-    return window.Strada?.web
+    return window.HotwireNative?.web || window.Strada?.web
   }
 }


### PR DESCRIPTION
Since Hotwire Native Bridge [v1.2.0](https://github.com/hotwired/hotwire-native-bridge/releases/tag/v1.2.0), the used window object is no longer `window.Strada` but `window.HotwireNative`.
This PR aims to support both, so it doesn't matter which version of the bridge or the native app is used.

Tested with:

- [x] Mobile app that uses `window.HotwireNative` and bridge that populates `window.HotwireNative` (latest versions)
- [x] Mobile app that uses `window.HotwireNative` and bridge that populates `window.Strada` (older bridge version)
- [x] Mobile app that uses `window.Strada` and bridge that populates `window.HotwireNative` (older mobile app version)
- [x] Mobile app that uses `window.Strada` and bridge that populates `window.Strada` (older versions)