### PR TITLE
Track `localStorage` changes

### DIFF
--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -237,6 +237,17 @@ export default class DevTools {
       { passive: true }
     )
 
+    // Listen for localStorage changes triggered by devtools in another (native) tab.
+    // This keeps the devtools UI in sync across tabs.
+    window.addEventListener("storage", (event) => {
+      if (event.key === "hotwire-native-dev-tools") {
+        this.state.updateLocalStorageSettings()
+        this.bubble.render()
+        this.bottomSheet.update(this.state.state)
+        this.bottomSheet.applySettingsFromStorage()
+      }
+    })
+
     this.hasEventListeners = true
   }
 

--- a/src/lib/DevToolsState.js
+++ b/src/lib/DevToolsState.js
@@ -11,7 +11,7 @@ export default class DevToolsState {
       bridgeIsConnected: false,
       supportsNativeStackView: false,
       consoleSearch: "",
-      activeTab: getSettings("activeTab") || "tab-bridge-components",
+      activeTab: this.storedActiveTab,
     }
     this.listeners = []
   }
@@ -86,7 +86,15 @@ export default class DevToolsState {
     this.state.consoleSearch = value
   }
 
+  updateLocalStorageSettings() {
+    this.state.activeTab = this.storedActiveTab
+  }
+
   get currentTime() {
     return new Date().toLocaleTimeString()
+  }
+
+  get storedActiveTab() {
+    return getSettings("activeTab") || "tab-bridge-components"
   }
 }


### PR DESCRIPTION
closes #30 

This PR adds synchronization between devtools instances across native app tabs by listening for localStorage changes and updating the UI accordingly.