### PR TITLE
Fix root view highlighting

### DIFF
--- a/src/components/BottomSheet.js
+++ b/src/components/BottomSheet.js
@@ -324,10 +324,13 @@ export default class BottomSheet {
   }
 
   nativeViewStackHTML(view) {
+    const removeTrailingSlash = (url) => {
+      return url?.replace(/\/+$/, "")
+    }
     const isMainView = ["UINavigationController", "NavigatorHost"].includes(view.type)
     const isTabBar = view.type === "UITabBarController"
     const isHotwireView = ["VisitableViewController", "HotwireWebFragment", "BackStackEntry"].includes(view.type)
-    const activeClass = view.url === this.currentUrl ? "current-view" : ""
+    const activeClass = removeTrailingSlash(view.url) === removeTrailingSlash(this.currentUrl) ? "current-view" : ""
     const wrapperClass = `viewstack-card ${activeClass} ${isMainView ? "main-view" : isHotwireView ? "hotwire-view" : isTabBar ? "tab-container" : "non-identified-view"}`
     const uniqueViewId = "viewstack-" + Math.random().toString(16).slice(2)
 


### PR DESCRIPTION
The highlighting of the root view in the native stack tab sometimes didn’t work.
The reason was that the native bridge component would send us the URL without a trailing slash:

- Bridge Component: "https://example.com"
- Native Stack: "https://example.com/"

As a result, the JavaScript string comparison would fail.
This only occurred when there was no pathname, so typically only the root view was affected.